### PR TITLE
Using double promise and double await

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,11 +22,13 @@ function setData(data) {
 }
 
 function fetchData() {
-  return axios.get("http://echo.jsontest.com/key/value/one/two");
+  return axios
+    .get("http://echo.jsontest.com/key/value/one/two")
+    .then(response => response.data);
 }
 
 function getData(dispatch) {
-  return () => fetchData().then(response => dispatch(setData(response.data)));
+  return () => fetchData().then(data => dispatch(setData(data)));
 }
 
 class App extends Component {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -8,7 +8,7 @@ it("renders without crashing", async () => {
     return Promise.resolve({ data: { one: 1, two: 2 } });
   });
   const div = document.createElement("div");
-  const component = await ReactDOM.render(<App />, div);
+  const component = await await ReactDOM.render(<App />, div);
 
   expect(div.textContent).toEqual("We have data!");
 });


### PR DESCRIPTION
When another promise is used (via `then`) to parse out the data in
response, the test starts to fail. In order to make the test pass,
another `await` can be used, but that seems odd.